### PR TITLE
Add cards order

### DIFF
--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -19,12 +19,16 @@ export const VALIDATION = {
   },
   MESSAGES: {
     REQUIRED: (field: string) => `${field} is required`,
+    MIN: (field: string, min: number) => `${field} must be more or equal ${min}`,
+    MAX: (field: string, max: number, info?: string) => `${field} cannot exceed ${max}${info ? ` (${info})` : ''}`,
+    DUPLICATE: (field: string, value: string | number, area: string) => `Duplicate ${field} "${value}" in the same ${area}`,
     MIN_LENGTH: (field: string, min: number) => `${field} must be at least ${min} characters`,
     MAX_LENGTH: (field: string, max: number) => `${field} cannot exceed ${max} characters`,
     PATTERN: (field: string, pattern: RegExp) => `${field} does not match required pattern: ${pattern.toString()}`,
   },
   ARRAY: {
     REQUIRED: (field: string): [boolean, string] => [true, VALIDATION.MESSAGES.REQUIRED(field)],
+    MIN: (field: string, min: number): [number, string] => [min, VALIDATION.MESSAGES.MIN(field, min)],
     MIN_LENGTH: (field: string, min: number): [number, string] => [min, VALIDATION.MESSAGES.MIN_LENGTH(field, min)],
     MAX_LENGTH: (field: string, max: number): [number, string] => [max, VALIDATION.MESSAGES.MAX_LENGTH(field, max)],
     PATTERN: (field: string, pattern: RegExp): [RegExp, string] => [

--- a/src/models/dashboard-template.ts
+++ b/src/models/dashboard-template.ts
@@ -2,7 +2,7 @@ import { Document, Schema, model } from 'mongoose';
 import { AppValidationError, validateAliasIdsDuplication } from '@utils';
 import { dashboardSchemaDefinition, type IDashboardBase } from './dashboard';
 
-export interface DashboardTemplateInput extends IDashboardBase {
+export interface DashboardTemplateInput extends IDashboardBase<string> {
   isTemplate: boolean;
 }
 

--- a/src/models/dashboard.ts
+++ b/src/models/dashboard.ts
@@ -151,12 +151,17 @@ const dashboardTransformFunction = (returnedDashboard: Record<string, unknown>) 
   delete returnedDashboard._id;
   delete returnedDashboard.__v;
   delete returnedDashboard.userId;
-  return returnedDashboard;
-};
 
-const tabTransformFunction = (returnedTab: Record<string, unknown>) => {
-  delete returnedTab._id;
-  return returnedTab;
+  if (returnedDashboard.tabs && Array.isArray(returnedDashboard.tabs)) {
+    returnedDashboard.tabs.forEach((tab: ITab) => {
+      if (tab.cards && Array.isArray(tab.cards)) {
+        delete tab._id;
+        tab.cards.sort((a: ICard, b: ICard) => (a.order || 0) - (b.order || 0));
+      }
+    });
+  }
+
+  return returnedDashboard;
 };
 
 dashboardSchema.set('toJSON', {
@@ -165,10 +170,6 @@ dashboardSchema.set('toJSON', {
 
 dashboardSchema.set('toObject', {
   transform: (_, returnedDashboard) => dashboardTransformFunction(returnedDashboard),
-});
-
-tabSchema.set('toObject', {
-  transform: (_, returnedTab) => tabTransformFunction(returnedTab),
 });
 
 export const Dashboard = model<IDashboard, IDashboardModel>('Dashboard', dashboardSchema);

--- a/src/models/dashboard.ts
+++ b/src/models/dashboard.ts
@@ -1,6 +1,6 @@
 import { Document, Model, Query, Schema, SchemaDefinition, model } from 'mongoose';
 import { VALIDATION } from '@constants';
-import { AppValidationError, validateAliasIdsDuplication } from '@utils';
+import { AppValidationError, validateAliasIdsDuplication, validateCardOrder } from '@utils';
 
 export interface IDashboard extends IDashboardInput, Document {}
 
@@ -12,11 +12,11 @@ export interface IDashboardInput extends IDashboardBase {
   userId: Schema.Types.ObjectId;
 }
 
-export interface IDashboardBase {
+export interface IDashboardBase<TItem = Schema.Types.ObjectId> {
   title: string;
   icon: string;
   aliasId: string;
-  tabs: ITab[];
+  tabs: ITab<TItem>[];
 }
 
 export interface ITab<TItem = Schema.Types.ObjectId> {
@@ -27,9 +27,10 @@ export interface ITab<TItem = Schema.Types.ObjectId> {
 }
 
 export interface ICard<TItem = Schema.Types.ObjectId> {
-  _id?: string;
+  _id: string;
   title?: string;
   layout: 'verticalLayout' | 'horizontalLayout' | 'singleInstrument';
+  order: number;
   items: TItem[];
 }
 
@@ -43,20 +44,20 @@ const cardSchema = new Schema<ICard>({
   layout: {
     type: String,
     enum: ['verticalLayout', 'horizontalLayout', 'singleInstrument'],
-    required: VALIDATION.ARRAY.REQUIRED('Card `layout"'),
+    required: VALIDATION.ARRAY.REQUIRED('Card "layout"'),
   },
 
   items: [{ type: Schema.Types.ObjectId, ref: 'Instrument', required: true }],
-});
 
-cardSchema.pre('validate', function (next) {
-  if (this.layout === 'singleInstrument' && this.items.length > 1) {
-    return next(new AppValidationError('"singleInstrument" cards can only contain 1 item'));
-  }
-  if (this.layout === 'verticalLayout' && this.items.length > 4) {
-    return next(new AppValidationError('"verticalLayout" cards can contain max 4 items'));
-  }
-  next();
+  order: {
+    type: Number,
+    required: VALIDATION.ARRAY.REQUIRED('Card "order"'),
+    min: VALIDATION.ARRAY.MIN('Card "order"', 0),
+    validate: {
+      validator: Number.isInteger,
+      message: 'Card "order" must be an integer',
+    },
+  },
 });
 
 const tabSchema = new Schema<ITab>({
@@ -76,6 +77,23 @@ const tabSchema = new Schema<ITab>({
   },
 
   cards: [cardSchema],
+});
+
+tabSchema.pre('validate', function (next) {
+  const cardOrderValidation = validateCardOrder(this.cards);
+  if (cardOrderValidation) {
+    const { order, duplicationIds, overMaxId } = cardOrderValidation;
+    if (overMaxId) {
+      return next(new AppValidationError(VALIDATION.MESSAGES.MAX(`Card "order"`, this.cards.length - 1, `card ${overMaxId}`)));
+    }
+    if (duplicationIds) {
+      return next(new AppValidationError(
+        VALIDATION.MESSAGES.DUPLICATE(`Card "order"`, order, `tab for cards "${duplicationIds.join('", "')}"`)
+      ));
+    }
+  }
+
+  next();
 });
 
 export const dashboardSchemaDefinition: SchemaDefinition = {
@@ -115,7 +133,9 @@ dashboardSchema.index({ userId: 1, aliasId: 1 }, { unique: true });
 dashboardSchema.pre('validate', function (next) {
   const duplicateTabAliasId = validateAliasIdsDuplication(this.tabs);
   if (duplicateTabAliasId) {
-    return next(new AppValidationError(`Duplicate Tab "aliasId" "${duplicateTabAliasId}" in the same dashboard`));
+    return next(new AppValidationError(
+      VALIDATION.MESSAGES.DUPLICATE(`Tab "aliasId"`, duplicateTabAliasId, `dashboard`)
+    ));
   }
   next();
 });

--- a/src/seed/seed.ts
+++ b/src/seed/seed.ts
@@ -59,8 +59,9 @@ async function seed() {
       ...tpl,
       tabs: tpl.tabs.map((tabTpl) => ({
         ...tabTpl,
-        cards: tabTpl.cards.map((cardTpl) => ({
+        cards: tabTpl.cards.map((cardTpl, i) => ({
           ...cardTpl,
+          order: i,
           items: cardTpl.itemAliasIds.map((aliasId: string) => aliasToId.get(aliasId) || aliasId),
         })),
       })),

--- a/src/services/dashboard.service.ts
+++ b/src/services/dashboard.service.ts
@@ -46,7 +46,7 @@ export class DashboardService implements IDashboardService {
 
   async getDashboardByAliasId(userId: string, aliasId: string): Promise<IDashboardResponse> {
     const dashboard = await Dashboard.findByAliasId(aliasId, userId);
-    if (!dashboard) throw new AppError('Dashboard not found', 404);
+    if (!dashboard) throw new AppError(`Dashboard "${aliasId}" not found`, 404);
 
     return await this.resolveDashboardWithInstruments(dashboard, userId);
   }
@@ -57,7 +57,7 @@ export class DashboardService implements IDashboardService {
     { title, icon, tabs }: IDashboardUpdate
   ): Promise<IDashboardResponse> {
     const dashboard = await Dashboard.findByAliasId(aliasId, userId);
-    if (!dashboard) throw new AppError('Dashboard not found', 404);
+    if (!dashboard) throw new AppError(`Dashboard "${aliasId}" not found`, 404);
 
     if (tabs) {
       await this.userInstrumentService.updateUserInstrumentsForDashboard({
@@ -78,12 +78,12 @@ export class DashboardService implements IDashboardService {
   }
 
   async deleteDashboard(userId: string, aliasId: string): Promise<void> {
-    const result = await Dashboard.findOneAndDelete<IDashboard>({ userId, aliasId });
-    if (!result?.value) throw new AppError('Dashboard not found', 404);
+    const deleted = await Dashboard.findOneAndDelete<IDashboard>({ userId, aliasId }).lean();
+    if (!deleted) throw new AppError(`Dashboard "${aliasId}" not found`, 404);
 
     await this.userInstrumentService.removeUserInstrumentsForDashboard({
       userId,
-      dashboardId: result.value._id,
+      dashboardId: deleted._id,
     });
   }
 

--- a/src/services/dashboard.service.ts
+++ b/src/services/dashboard.service.ts
@@ -94,7 +94,7 @@ export class DashboardService implements IDashboardService {
     return await this.addDashboards(userId, templates);
   }
 
-  private async addDashboards(userId: string, dashboards: IDashboardBase[]): Promise<IDashboardCreationResult> {
+  private async addDashboards(userId: string, dashboards: IDashboardBase<string>[]): Promise<IDashboardCreationResult> {
     const dashboardsCreation: IDashboardCreationResult = {
       created: [],
       skipped: [],

--- a/src/services/user-instrument.service.ts
+++ b/src/services/user-instrument.service.ts
@@ -76,8 +76,7 @@ export class UserInstrumentService implements IUserInstrumentService {
     for (const instrumentId of updatedInstrumentIds) {
       const instrument = await this.instrumentService.getInstrumentById(instrumentId, session);
       if (!instrument) {
-        console.warn(`Instrument with ID ${instrumentId} not found. Skipping.`);
-        continue;
+        throw new AppError(`Instrument with ID ${instrumentId} not found`, 404);
       }
 
       if (!existingUserInstrumentsIds.includes(instrumentId)) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './token.utils';
 export * from './hash.utils';
 export * from './validate-alias-ids-duplication.utils';
+export * from './validate-value-duplication.utils';
 export * from './type-guards';
 export * from './errors.utils';
 export * from './validate-instrument-data.utils';

--- a/src/utils/validate-instrument-data.utils.ts
+++ b/src/utils/validate-instrument-data.utils.ts
@@ -5,7 +5,6 @@ export function validateInstrumentData(
   state?: boolean,
   value?: IInstrument['value']
 ): string | null {
-  console.log('Validating instrument data:', { type, state, value });
   if (type === 'device') {
     if (value?.amount !== undefined) {
       return 'Devices cannot have "value" defined';

--- a/src/utils/validate-value-duplication.utils.ts
+++ b/src/utils/validate-value-duplication.utils.ts
@@ -1,0 +1,26 @@
+export function validateCardOrder(entities: { _id: string; order: number }[]): {order: number, duplicationIds?: string[], overMaxId?: string} | null {
+  const orderValueIdMap = new Map<number, string>();
+
+  for (const entity of entities) {
+    const { _id, order } = entity;
+    if (order !== undefined && order !== null) {
+      if (orderValueIdMap.has(order)) {
+        return {
+          order,
+          duplicationIds: [orderValueIdMap.get(order)!, _id],
+        };
+      }
+
+      if (order > entities.length - 1) {
+        return {
+          order,
+          overMaxId: _id,
+        };
+      }
+
+      orderValueIdMap.set(order, _id);
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
- add order for cards (with validation and changes to seeding);
- return cards sorted by order;
-  throw an error if an unidentified instrument is present in a changed or new dashboard;
-  fix dashboard deleting;